### PR TITLE
Fix #133 - readme example does not compile

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -234,7 +234,8 @@ var flow = nools.compile(noolsSource, {
     scope: {
         //the logger you want your flow to use.
         logger: logger
-    }
+    },
+    name: 'person name is bob'
 });
 ```
 


### PR DESCRIPTION
adding "name" parameter for accuracy in readme.md