### PR TITLE
Add custom constraint using function and resolve types in scope

### DIFF
--- a/lib/constraint.js
+++ b/lib/constraint.js
@@ -236,5 +236,22 @@ Constraint.extend({
     }
 }).as(exports, "FromConstraint");
 
+Constraint.extend({
+  instance: {
+    constructor: function(func, options) {
+      this.type = "custom";
+      this.fn = func;
+      this.options = options;
+    },
+
+    equal: function(constraint) {
+      return instanceOf(constraint, this._static) && this.fn === constraint.constraint;
+    },
+
+    "assert": function(fact, fh) {
+      return this.fn(fact, fh);
+    }
+  }
+}).as(exports, "CustomConstraint");
 
 

--- a/lib/constraintMatcher.js
+++ b/lib/constraintMatcher.js
@@ -458,6 +458,9 @@ exports.getSourceMatcher = function (rule, options, equality) {
 };
 
 exports.toConstraints = function (constraint, options) {
+    if(typeof constraint === 'function') {
+      return [new atoms.CustomConstraint(constraint, options)];
+    }
     //constraint.split("&&")
     return lang.toConstraints(constraint, options);
 };

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -16,6 +16,14 @@ var extd = require("./extended"),
     FromExistsPattern = pattern.FromExistsPattern,
     CompositePattern = pattern.CompositePattern;
 
+var parseConstraint = function(constraint) {
+    if (typeof constraint === 'function') {
+      // No parsing is needed for constraint functions
+      return constraint;
+    }
+    return parser.parseConstraint(constraint);
+};
+
 var parseExtra = extd
     .switcher()
     .isUndefinedOrNull(function () {
@@ -66,54 +74,62 @@ var normailizeConstraint = extd
     })
     .switcher();
 
-
-var getParamTypeSwitch = extd
+var getParamType = function getParamType(type, scope) {
+  scope = scope || {};
+  var getParamTypeSwitch = extd
     .switcher()
-    .isEq("string", function () {
-        return String;
+    .isEq("string", function() {
+      return String;
     })
-    .isEq("date", function () {
-        return Date;
+    .isEq("date", function() {
+      return Date;
     })
-    .isEq("array", function () {
-        return Array;
+    .isEq("array", function() {
+      return Array;
     })
-    .isEq("boolean", function () {
-        return Boolean;
+    .isEq("boolean", function() {
+      return Boolean;
     })
-    .isEq("regexp", function () {
-        return RegExp;
+    .isEq("regexp", function() {
+      return RegExp;
     })
-    .isEq("number", function () {
-        return Number;
+    .isEq("number", function() {
+      return Number;
     })
-    .isEq("object", function () {
-        return Object;
+    .isEq("object", function() {
+      return Object;
     })
-    .isEq("hash", function () {
-        return Object;
+    .isEq("hash", function() {
+      return Object;
     })
-    .def(function (param) {
-        throw new TypeError("invalid param type " + param);
+    .def(function(param) {
+      throw new TypeError("invalid param type " + param);
     })
     .switcher();
 
-
-var getParamType = extd
+  var _getParamType = extd
     .switcher()
-    .isString(function (param) {
+    .isString(function(param) {
+      var t = scope[param];
+      if(!t) {
         return getParamTypeSwitch(param.toLowerCase());
+      } else {
+        return t;
+      }
     })
-    .isFunction(function (func) {
-        return func;
+    .isFunction(function(func) {
+      return func;
     })
-    .deepEqual([], function () {
-        return Array;
+    .deepEqual([], function() {
+      return Array;
     })
-    .def(function (param) {
-        throw  new Error("invalid param type " + param);
+    .def(function(param) {
+      throw  new Error("invalid param type " + param);
     })
     .switcher();
+
+  return _getParamType(type);
+};
 
 var parsePattern = extd
     .switcher()
@@ -130,20 +146,20 @@ var parsePattern = extd
         if (condition[4] && condition[4].from) {
             return [
                 new FromNotPattern(
-                    getParamType(condition[0]),
+                    getParamType(condition[0], condition.scope),
                     condition[1] || "m",
-                    parser.parseConstraint(condition[2] || "true"),
+                    parseConstraint(condition[2] || "true"),
                     condition[3] || {},
-                    parser.parseConstraint(condition[4].from),
+                    parseConstraint(condition[4].from),
                     {scope: condition.scope, pattern: condition[2]}
                 )
             ];
         } else {
             return [
                 new NotPattern(
-                    getParamType(condition[0]),
+                    getParamType(condition[0], condition.scope),
                     condition[1] || "m",
-                    parser.parseConstraint(condition[2] || "true"),
+                    parseConstraint(condition[2] || "true"),
                     condition[3] || {},
                     {scope: condition.scope, pattern: condition[2]}
                 )
@@ -156,20 +172,20 @@ var parsePattern = extd
         if (condition[4] && condition[4].from) {
             return [
                 new FromExistsPattern(
-                    getParamType(condition[0]),
+                    getParamType(condition[0], condition.scope),
                     condition[1] || "m",
-                    parser.parseConstraint(condition[2] || "true"),
+                    parseConstraint(condition[2] || "true"),
                     condition[3] || {},
-                    parser.parseConstraint(condition[4].from),
+                    parseConstraint(condition[4].from),
                     {scope: condition.scope, pattern: condition[2]}
                 )
             ];
         } else {
             return [
                 new ExistsPattern(
-                    getParamType(condition[0]),
+                    getParamType(condition[0], condition.scope),
                     condition[1] || "m",
-                    parser.parseConstraint(condition[2] || "true"),
+                    parseConstraint(condition[2] || "true"),
                     condition[3] || {},
                     {scope: condition.scope, pattern: condition[2]}
                 )
@@ -177,24 +193,27 @@ var parsePattern = extd
         }
     })
     .def(function (condition) {
+        if (typeof condition === 'function') {
+          return [condition];
+        }
         condition = normailizeConstraint(condition);
         if (condition[4] && condition[4].from) {
             return [
                 new FromPattern(
-                    getParamType(condition[0]),
+                    getParamType(condition[0], condition.scope),
                     condition[1] || "m",
-                    parser.parseConstraint(condition[2] || "true"),
+                    parseConstraint(condition[2] || "true"),
                     condition[3] || {},
-                    parser.parseConstraint(condition[4].from),
+                    parseConstraint(condition[4].from),
                     {scope: condition.scope, pattern: condition[2]}
                 )
             ];
         } else {
             return [
                 new ObjectPattern(
-                    getParamType(condition[0]),
+                    getParamType(condition[0], condition.scope),
                     condition[1] || "m",
-                    parser.parseConstraint(condition[2] || "true"),
+                    parseConstraint(condition[2] || "true"),
                     condition[3] || {},
                     {scope: condition.scope, pattern: condition[2]}
                 )

--- a/test/rules.test.js
+++ b/test/rules.test.js
@@ -428,6 +428,51 @@ it.describe("Rule", function (it) {
             });
         });
 
+        it.describe("custom function as constraints", function (it) {
+
+          var MyConstraint = function(fact) {
+            return true;
+          };
+
+          it.should("create for String function with custom constraint", function() {
+            var rule = rules.createRule("My Rule", [String, "s", MyConstraint], cb);
+            assert.isNotNull(rule);
+            assert.lengthOf(rule, 1);
+            rule = rule[0];
+            assert.equal(rule.name, "My Rule");
+            assert.isNotNull(rule.pattern);
+            var pattern = rule.pattern;
+            assert.equal(pattern.alias, "s");
+            assert.lengthOf(pattern.constraints, 2);
+            assert.instanceOf(pattern.constraints[0], constraints.ObjectConstraint);
+            assert.equal(pattern.constraints[0].constraint, String);
+            assert.instanceOf(pattern.constraints[1], constraints.CustomConstraint);
+            assert.strictEqual(rule.cb, cb);
+          });
+        });
+
+        it.describe("custom type via scope", function (it) {
+
+            var MyType = function(name) {
+                this.name = name;
+            };
+
+            it.should("create for String function with custom constraint", function() {
+                var rule = rules.createRule("My Rule", {scope: {MyType: MyType}}, ['MyType', "s", "s.name === 'X'"], cb);
+                assert.isNotNull(rule);
+                assert.lengthOf(rule, 1);
+                rule = rule[0];
+                assert.equal(rule.name, "My Rule");
+                assert.isNotNull(rule.pattern);
+                var pattern = rule.pattern;
+                assert.equal(pattern.alias, "s");
+                assert.lengthOf(pattern.constraints, 2);
+                assert.instanceOf(pattern.constraints[0], constraints.ObjectConstraint);
+                assert.equal(pattern.constraints[0].constraint, MyType);
+                assert.strictEqual(rule.cb, cb);
+            });
+        });
+
         it.should("create a composite rule", function () {
             var rule = rules.createRule("My Rule", [
                 ["string", "s"],


### PR DESCRIPTION
The PR adds two things:

1. Allow the constraint to be a JS function in addition to nools expression
2. Allow type names to be resolved with `options.scope`

Motivations:

We try to use `nools` as the rules engine for LoopBack's policy framework. LoopBack has its own JSON format to describe rules/constraints/actions that will be transformed to the formats consumable by `nools`.