### PR TITLE
Add the missing bind for assert

### DIFF
--- a/lib/constraint.js
+++ b/lib/constraint.js
@@ -244,6 +244,7 @@ Constraint.extend({
             this.type = "custom";
             this.fn = func;
             this.options = options;
+            extd.bindAll(this, ["assert"]);
         },
 
         equal: function (constraint) {


### PR DESCRIPTION
@doug-martin The previous PR is missing a `bind` to ensure `assert` has the correct receiver.