### PR TITLE
Fixes path handling for imports under windows

### DIFF
--- a/lib/parser/nools/util.js
+++ b/lib/parser/nools/util.js
@@ -59,13 +59,16 @@ exports.getParamList = function (str) {
 };
 
 exports.resolve = function (from, to) {
+    if (process.platform === 'win32') {
+        to = to.replace(/\//g, '\\');
+    }
     if (path.extname(from) !== '') {
         from = path.dirname(from);
     }
     if (to.split(pathSep).length === 1) {
         return to;
     }
-    return path.resolve(from, to);
+    return path.resolve(from, to).replace(/\\/g, '/');
 
 };
 

--- a/test/noolsParser.test.js
+++ b/test/noolsParser.test.js
@@ -83,7 +83,7 @@ it.describe("nools dsl parser", function (it) {
         it.should("resolve relative require paths", function () {
             var parsed = noolsParser.parse("global util = require('../util');", "./rules/test.nools");
             assert.equal(parsed.scope[0].name, 'util');
-            assert.equal(parsed.scope[0].body, "require('" + path.resolve("./rules", "../util") + "')");
+            assert.equal(parsed.scope[0].body, "require('" + path.resolve("./rules", "../util").replace(/\\/g, '/') + "')");
         });
 
         it.should("parse a member look up", function () {
@@ -131,7 +131,7 @@ it.describe("nools dsl parser", function (it) {
             it.should("parse a relative path and default to process.cwd()", function () {
                 var called = false;
                 fs.readFileSync = function (file, encoding) {
-                    assert.equal(file, path.resolve(process.cwd(), './test.nools'));
+                    assert.equal(file, path.resolve(process.cwd(), './test.nools').replace(/\\/g, '/'));
                     assert.equal(encoding, "utf8");
                     called = true;
                     return "";
@@ -143,7 +143,7 @@ it.describe("nools dsl parser", function (it) {
             it.should("parse a relative path and use the file path", function () {
                 var called = false;
                 fs.readFileSync = function (file, encoding) {
-                    assert.equal(file, path.resolve("./rules", './test.nools'));
+                    assert.equal(file, path.resolve("./rules", './test.nools').replace(/\\/g, '/'));
                     assert.equal(encoding, "utf8");
                     called = true;
                     return "";
@@ -155,7 +155,7 @@ it.describe("nools dsl parser", function (it) {
             it.should("parse a absolute path and not change the location ", function () {
                 var called = false;
                 fs.readFileSync = function (file, encoding) {
-                    assert.equal(file, "/rules/test.nools");
+                    assert.equal(file, path.resolve("/rules/test.nools").replace(/\\/g, '/'));
                     assert.equal(encoding, "utf8");
                     called = true;
                     return "";
@@ -167,7 +167,7 @@ it.describe("nools dsl parser", function (it) {
             it.should("should parse import with optional ';'", function () {
                 var called = false;
                 fs.readFileSync = function (file, encoding) {
-                    assert.equal(file, "/rules/test.nools");
+                    assert.equal(file, path.resolve("/rules/test.nools").replace(/\\/g, '/'));
                     assert.equal(encoding, "utf8");
                     called = true;
                     return "";
@@ -208,9 +208,9 @@ it.describe("nools dsl parser", function (it) {
                     ],
                     "scope": [],
                     "loaded": [
-                        require.resolve("./rules/import/import1.nools"),
-                        require.resolve("./rules/import/import2.nools"),
-                        require.resolve("./rules/import/import3.nools")
+                        require.resolve("./rules/import/import1.nools").replace(/\\/g, '/'),
+                        require.resolve("./rules/import/import2.nools").replace(/\\/g, '/'),
+                        require.resolve("./rules/import/import3.nools").replace(/\\/g, '/')
                     ],
                     "file": source
                 });


### PR DESCRIPTION
- when importing, replace all '/' with '\' so path assertion comes back
  properly

- when going out, ensure '/' are used under windows so requires continue
  to work properly.

- fixes a few tests under windows that were assuming POSIX environment

Fixes #192