### PR TITLE
fix memory leak

### DIFF
--- a/lib/nodes/equalityNode.js
+++ b/lib/nodes/equalityNode.js
@@ -32,7 +32,7 @@ AlphaNode.extend({
             if (memory[hashCode]) {
                 this.__propagate("retract", context);
             }
-            memory[hashCode] = null;
+            delete memory[hashCode];
         },
 
         toString: function () {


### PR DESCRIPTION
Fix #156 

Strings as objet keys were kept in an object. After 100k iterations against the issue code exemple, the memory size is stable.