### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -776,7 +776,7 @@ When declaring a flow it is defined with a default conflict resolution strategy.
 
 The default conflict resolution strategy consists of `salience` and `activationRecency`.
 
-###Examples
+### Examples
 
 **Example 1**
 
@@ -815,7 +815,7 @@ In the above example activation 2 would be fired since it is the most recent act
 ```
 In this example activation 1 would fire because it has a greater salience
 
-###Overidding The Default Strategy
+### Overidding The Default Strategy
 
 To override the default strategy you can use the `conflictResolution` method on a flow.
 
@@ -1414,7 +1414,7 @@ rule "my rule", {
 
 <a name="exists-constraint"></a>
 
-###Exists Constraint
+### Exists Constraint
 
 `exists` is the logical inversion of a `not` constraint. It checks for the existence of a fact in memory.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
